### PR TITLE
Use default pointer for non links

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -173,6 +173,9 @@ main {
   a {
     color: inherit;
   }
+  a:not[href] {
+    cursor: default;
+  }
   a:hover {
     color: #666666;
   }


### PR DESCRIPTION
Because some of the layout elements are anchor tags, the `auto` cursor is the `pointer`. Ideally, they'd be converted to `div`, but this css rule can temporarily fix it.